### PR TITLE
Andy123/2023 09 09 review

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,32 @@
-# Randomizer Overide
-This EM will allow for manual overide of "randomizer" fields.  Namely the fields where values are drawn from a pregenerated allocation table.
+# Randomizer Override
 
-This EM will inject appropriate UI into the "add/edit" workflow to allow the user to manually select the desired value, and subsequently "claim" the allocated value in the allocation table.
+## What it Does
+The external module permits only SELECTED USERS to manually SET the value normally set by the built-in REDCap allocation-based randomization.  This can be especially useful if a manual/envelope-based method was used to randomize a participant while REDCap was offline or unavailable.
+
+When a selected user manually sets the random output for a record, an allocation entry is consumed if available.  This means that so long as you randomize additional records in the future, your project should re-stabilize to the allocation ratio defined in your allocation table.
+
+## How it Works
+The EM injects appropriate UI into the "add/edit" workflow of the randomization instrument to allow the user to manually select the desired value, and subsequently "claim" the allocated value in the allocation table.
 
 If all allocated values are already claimed the UI inputs will remain "disabled"
 
-Below is a quick visual overview of what the EM will add to the project:
-
-![Fig 1](https://raw.githubusercontent.com/susom/manual-randomization/master/images/allowed_users.png)
+#### Only authorized users will have this privilege
+![Fig 1](images/allowed_users.png)
 Be sure to set usernames with override permissions in the EM config settings.
 
-![Fig 2](https://raw.githubusercontent.com/susom/manual-randomization/master/images/red_button.png)
+#### Manual Selection button will appear for un-randomized records
+![Fig 2](images/red_button.png)
 Fields chosen to be Randomized fields will have the default "Randomize" button with a new red button labeled "Manual Selection" next to them.
 
-![Fig 3](https://raw.githubusercontent.com/susom/manual-randomization/master/images/inject_ui.png)
-When the Manual Selection button is clicked , if pre-requisite fields are filled in, then the options will be enabled and a value can be chosen.
+#### Upon selection, you can set the new outcome group
+![Fig 3](images/inject_ui.png)
+When the Manual Selection button is clicked and strata values are already defined, the user will be able to select the desired random outcome group.
 
-![Fig 4](https://raw.githubusercontent.com/susom/manual-randomization/master/images/red_note.png)
+![Fig 4](images/red_note.png)
 Once a value is set (along with reason for manual selection) the selections will be disabled with the reason displayed in red.
 
-![Fig 5](https://raw.githubusercontent.com/susom/manual-randomization/master/images/log_link.png)
+#### A log of manual randomization overrides with reasons
+![Fig 5](images/log_link.png)
 
-![Fig 6](https://raw.githubusercontent.com/susom/manual-randomization/master/images/manual_log_page.png)
+![Fig 6](images/manual_log_page.png)
 A log of Randomizations overridden can be viewed with this EM link

--- a/RandomizerOverride.php
+++ b/RandomizerOverride.php
@@ -444,8 +444,9 @@ class RandomizerOverride extends \ExternalModules\AbstractExternalModule {
 		$results    = json_decode($q,true);
 
 		foreach($results as $result){
-			$record_id 	= $result["record_id"];
-			$outcome 	= $result["outcome"];
+			$record_id 	= $this->escape($result["record_id"]);
+			$outcome 	= $this->escape($result["outcome"]);
+            // TODO: @IRVINS - this "outcome" above doesn't look right
 			$overridden_records[$record_id]["grouping"] = $outcome;
 		}
 		return $overridden_records;

--- a/ajax/handler.php
+++ b/ajax/handler.php
@@ -1,26 +1,20 @@
 <?php
 namespace Stanford\RandomizerOverride;
-/** @var \Stanford\RandomizerOverride\RandomizerOverride $module */
+/** @var RandomizerOverride $module */
 
 use REDCap;
 
-$action                 = !empty($_POST["action"]) ? filter_var($_POST["action"], FILTER_SANITIZE_STRING) : null;
-$record_id              = isset($_POST["record_id"])  ? filter_var($_POST["record_id"] , FILTER_SANITIZE_NUMBER_INT): NULL ;
-
-//FILTER WHEN INPUT IS ARRAY, CAN BE EXPLICIT LIKE WITH $args OR IF ONLY ONE KNOWN TYPE CAN JUST USE FILTER_SANITIZE_STRING
-$args = array(
-    'source_field1'     => FILTER_SANITIZE_STRING,
-    'source_field2'     => FILTER_SANITIZE_STRING,
-);
-$source_fields          = isset($_POST["source_fields"])  ? filter_var_array($_POST["source_fields"], $args)  : NULL ;
-$strata_fields          = isset($_POST["strata_fields"])  ? filter_var_array($_POST["strata_fields"], $args)  : NULL ;
+$action                 = $module->escape($_POST["action"]);
+$record_id              = $module->escape($_POST["record_id"]);
+$source_fields          = $module->escape($_POST["source_fields"]);
+$strata_fields          = $module->escape($_POST["strata_fields"]);
 $strata_source_lookup   = array_flip($strata_fields);
 
 switch($action){
     case "check_remaining":
         // Take the current instruments strata values (which may be unsaved)
         // check record for remaining strata fields outside of this instrument
-        $check_fields   = isset($_POST["check_fields"])  ? filter_var_array($_POST["check_fields"], FILTER_SANITIZE_STRING) : NULL ;
+        $check_fields   = $module->escape($_POST["check_fields"]);
         $source_fields  = $module->remainingStrataLookUp($record_id, $strata_source_lookup, $check_fields, $source_fields);
         break;
 

--- a/ajax/handler.php
+++ b/ajax/handler.php
@@ -1,6 +1,6 @@
 <?php
-namespace Stanford\RandomizerOveride;
-/** @var \Stanford\RandomizerOveride\RandomizerOveride $module */
+namespace Stanford\RandomizerOverride;
+/** @var \Stanford\RandomizerOverride\RandomizerOverride $module */
 
 use REDCap;
 

--- a/config.json
+++ b/config.json
@@ -68,7 +68,7 @@
 	"compatibility": {
 		"php-version-min": "",
 		"php-version-max": "",
-		"redcap-version-min": "",
+		"redcap-version-min": "13.1.2",
 		"redcap-version-max": ""
 	}
 }

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
-	"name": "Randomizer Overide",
+	"name": "Randomizer Override",
 
-	"namespace": "Stanford\\RandomizerOveride",
+	"namespace": "Stanford\\RandomizerOverride",
 
 	"description": "EM that allows manual override of values drawn from Randomized Allocation Tables",
 
@@ -20,20 +20,14 @@
 		}
 	],
 
-	"permissions": [
-		"redcap_data_entry_form_top",
-		"redcap_save_record",
-		"redcap_module_link_check_display"
-	],
-
-	"framework-version": 8,
+	"framework-version": 13,
 
 	"enable-every-page-hooks-on-system-pages": false,
 
 	"links": {
 		"project": [
 			{
-		        "name": "Log of Manual Randomization Overides",
+		        "name": "Log of Manual Randomization Overrides",
 		        "icon": "fas fa-table",
 		        "url": "pages/manual_log.php",
 		        "show-header-and-footer": false
@@ -50,7 +44,7 @@
 	"project-settings": [
 		{
 			"key": "override-user-list",
-			"name": "<b>Allowed Users List</b> <br>Comma seperated list of [Userids] who are allowed to manually overide randomization fields",
+			"name": "<b>Allowed Users List</b> <br>Comma seperated list of usernames who are allowed to manually override the randomization output",
 			"required": false,
 			"type": "text"
 		},
@@ -61,7 +55,6 @@
 			"type": "checkbox"
 		}
 	],
-
 
 	"system-settings": [
 		{

--- a/emLoggerTrait.php
+++ b/emLoggerTrait.php
@@ -1,6 +1,6 @@
 <?php
-namespace Stanford\RandomizerOveride;
-/** @var RandomizerOveride $this */
+namespace Stanford\RandomizerOverride;
+/** @var RandomizerOverride $this */
 
 trait emLoggerTrait
 {

--- a/pages/manual_log.php
+++ b/pages/manual_log.php
@@ -11,8 +11,8 @@ echo "<div class='container'>";
 echo "<table class='table' id='man_rando_logs'>";
 echo "<thead><tr><th>Record ID</th><th>userid</th><th>project status</th><th>Change Reason</th><th>date</th><th>Grouping</th></thead></tr>";
 echo "<tbody>";
-foreach($overridden_records as $record_id => $record_raw){
-    $record = $module->escape($record_raw);
+foreach($overridden_records as $record_id => $record){
+    // $record = $module->escape($record_raw);
     echo "<tr>";
     echo "<td>$record_id</td>";
     echo "<td>".$record["user"]."</td>";

--- a/pages/manual_log.php
+++ b/pages/manual_log.php
@@ -1,6 +1,6 @@
 <?php
 namespace Stanford\RandomizerOverride;
-/** @var \Stanford\RandomizerOverride\RandomizerOverride $module */
+/** @var RandomizerOverride $module **/
 
 require_once APP_PATH_DOCROOT . 'ProjectGeneral/header.php';
 

--- a/pages/manual_log.php
+++ b/pages/manual_log.php
@@ -4,15 +4,15 @@ namespace Stanford\RandomizerOverride;
 
 require_once APP_PATH_DOCROOT . 'ProjectGeneral/header.php';
 
-
-$overriden_records = $module->getManualRandomizationOverrideLogs();
+$overridden_records = $module->getManualRandomizationOverrideLogs();
 
 echo "<h3>Log of Manual Randomization Overrides</h3>";
 echo "<div class='container'>";
 echo "<table class='table' id='man_rando_logs'>";
 echo "<thead><tr><th>Record ID</th><th>userid</th><th>project status</th><th>Change Reason</th><th>date</th><th>Grouping</th></thead></tr>";
 echo "<tbody>";
-foreach($overriden_records as $record_id => $record){
+foreach($overridden_records as $record_id => $record_raw){
+    $record = $module->escape($record_raw);
     echo "<tr>";
     echo "<td>$record_id</td>";
     echo "<td>".$record["user"]."</td>";

--- a/pages/manual_log.php
+++ b/pages/manual_log.php
@@ -1,13 +1,13 @@
 <?php
-namespace Stanford\RandomizerOveride;
-/** @var \Stanford\RandomizerOveride\RandomizerOveride $module */
+namespace Stanford\RandomizerOverride;
+/** @var \Stanford\RandomizerOverride\RandomizerOverride $module */
 
 require_once APP_PATH_DOCROOT . 'ProjectGeneral/header.php';
 
 
-$overriden_records = $module->getManualRandomizationOverideLogs();
+$overriden_records = $module->getManualRandomizationOverrideLogs();
 
-echo "<h3>Log of Manual Randomization Overides</h3>";
+echo "<h3>Log of Manual Randomization Overrides</h3>";
 echo "<div class='container'>";
 echo "<table class='table' id='man_rando_logs'>";
 echo "<thead><tr><th>Record ID</th><th>userid</th><th>project status</th><th>Change Reason</th><th>date</th><th>Grouping</th></thead></tr>";


### PR DESCRIPTION
Hey @irvins - did some comments and mild refactoring.  A few things:

1) This needs to be tested!  
2) It seems like it doesn't take into account longitudinal projects -- the events for the strata are not used.  I worry that if you had a strata from a previous event (e,g. [screening_arm_1][gender] combined with a [baseline_arm_1][lab_result]) the module wouldn't work.  

We should also start using the `$this->escape()` method that is in the newer framework versions.

Let me know what you think...